### PR TITLE
Fix issue of connect to market service in Some devices.

### DIFF
--- a/billing/src/main/java/ir/myket/billingclient/IabHelper.java
+++ b/billing/src/main/java/ir/myket/billingclient/IabHelper.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.RemoteException;
@@ -274,7 +275,12 @@ public class IabHelper {
 
     private boolean isMarketInstalled(String marketId) {
         try {
-            return mContext.getPackageManager().getApplicationInfo(marketId, 0) != null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                mContext.getPackageManager().getApplicationInfo(marketId, PackageManager.MATCH_DISABLED_COMPONENTS);
+            } else {
+                mContext.getPackageManager().getApplicationInfo(marketId, 0);
+            }
+            return true;
         } catch (PackageManager.NameNotFoundException e) {
             return false;
         } catch (Exception e) {

--- a/billing/src/main/java/ir/myket/billingclient/util/BroadcastIAB.java
+++ b/billing/src/main/java/ir/myket/billingclient/util/BroadcastIAB.java
@@ -78,7 +78,12 @@ public class BroadcastIAB extends IAB {
 
     public boolean connect(Context context, OnBroadCastConnectListener listener) {
         try {
-            PackageInfo pInfo = context.getPackageManager().getPackageInfo(marketId, 0);
+            PackageInfo pInfo;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                pInfo = context.getPackageManager().getPackageInfo(marketId, PackageManager.MATCH_DISABLED_COMPONENTS);
+            } else {
+                pInfo = context.getPackageManager().getPackageInfo(marketId, 0);
+            }
             int versionCode;
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
                 versionCode = (int) pInfo.getLongVersionCode();

--- a/billing/src/main/java/ir/myket/billingclient/util/ServiceIAB.java
+++ b/billing/src/main/java/ir/myket/billingclient/util/ServiceIAB.java
@@ -76,8 +76,13 @@ public class ServiceIAB extends IAB {
         serviceIntent.setPackage(marketId);
 
         PackageManager pm = context.getPackageManager();
-        List<ResolveInfo> intentServices = pm.queryIntentServices(serviceIntent, 0);
-        if (intentServices != null && !intentServices.isEmpty()) {
+        List<ResolveInfo> intentServices;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            intentServices = pm.queryIntentServices(serviceIntent, PackageManager.MATCH_DISABLED_COMPONENTS);
+        } else {
+            intentServices = pm.queryIntentServices(serviceIntent, 0);
+        }
+        if (!intentServices.isEmpty()) {
             try {
                 boolean result = context.bindService(serviceIntent, mServiceConn, Context.BIND_AUTO_CREATE);
                 if (!result) {


### PR DESCRIPTION
#### Reference Issues/PRs 
None
#### What does this implement/fix?
We are using the Myket billing SDK for our app, [Nazdika](https://myket.ir/app/com.nazdika.app?utm_source=search-ads-gift&utm_medium=cpc).
After monitoring the Myket payments, we have found that the purchase success rate on some devices, especially **Samsung** devices, is low.
After extensive debugging and research, we have finally identified the issue.
Samsung devices have a feature called **Deep Sleeping Apps**, which can be found in the **Device Care app under Battery > Background Usage Limits > Deep Sleeping Apps.**
When a user does not use an app for a long time, the system puts the app in the Deep Sleeping list, and apps on this list are disabled. Therefore, when we query the package manager to check if the market is installed or retrieve the market service information, the system always returns false or throws a "package not installed" exception because our query by default does not include disabled components. (We can verify this behavior by checking the Google Play Store update page, where disabled apps are not checked for updates.)
However, when this issue occurs, the start setup callback is never called.
I fixed the issue with edit package manager queries.
#### Any other comments?
No