### PR TITLE
Fix issue of activity orientation on Android Oreo

### DIFF
--- a/billing/src/main/java/ir/myket/billingclient/util/DialogActivity.java
+++ b/billing/src/main/java/ir/myket/billingclient/util/DialogActivity.java
@@ -65,10 +65,12 @@ public class DialogActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         iabLogger.logDebug("Launching install myket activity");
-        setRequestedOrientation(
-                getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ?
-                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE :
-                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+            setRequestedOrientation(
+                    getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ?
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE :
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        }
 
         BottomSheetDialog dialog = new BottomSheetDialog(this);
         LayoutInflater inflater = LayoutInflater.from(this);

--- a/billing/src/main/java/ir/myket/billingclient/util/ProxyBillingActivity.java
+++ b/billing/src/main/java/ir/myket/billingclient/util/ProxyBillingActivity.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 
@@ -32,10 +33,13 @@ public class ProxyBillingActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         iabLogger.logDebug("Launching Store billing flow");
-        setRequestedOrientation(
-                getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ?
-                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE :
-                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+            setRequestedOrientation(
+                    getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ?
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE :
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        }
+
         try {
             purchaseBillingReceiver = (ResultReceiver) getIntent().getParcelableExtra(BILLING_RECEIVER_KEY);
             if (getIntent().getParcelableExtra(RESPONSE_BUY_INTENT) instanceof PendingIntent) {


### PR DESCRIPTION
#### Reference Issues/PRs 
None
#### What does this implement/fix?
Google throws `java.lang.IllegalStateException: Only fullscreen opaque activities can request orientation` exception on Activity's onCreate method after v27, their meaning is : if an Activity is translucent or floating, its orientation should be relied on parent(background) Activity, can't make decision on itself.
#### Any other comments?
No