### PR TITLE
fix: guard checkBillingSupported against a disposed helper (#21)

### DIFF
--- a/billing/src/main/java/ir/myket/billingclient/IabHelper.java
+++ b/billing/src/main/java/ir/myket/billingclient/IabHelper.java
@@ -299,6 +299,13 @@ public class IabHelper {
     }
 
     private void checkBillingSupported(final OnIabSetupFinishedListener listener, boolean broadcastScenario) {
+        // This runs from a service-connection / broadcast callback, which can
+        // arrive after dispose() has already nulled mContext. Bail instead of
+        // dereferencing it: the listener belongs to a component that is gone.
+        if (mDisposed || mContext == null) {
+            logger.logDebug("checkBillingSupported: helper already disposed, ignoring.");
+            return;
+        }
         String packageName = mContext.getPackageName();
 		IAB connection = iabConnection;
 


### PR DESCRIPTION
Fixes #21 — still reproducible on 1.19.

### The crash

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.String android.content.Context.getPackageName()' on a null object reference
  at ir.myket.billingclient.IabHelper.checkBillingSupported(IabHelper.java:302)
  at ir.myket.billingclient.IabHelper$1.connected(IabHelper.java:240)
  at ir.myket.billingclient.util.ServiceIAB$1.onServiceConnected(ServiceIAB.java:73)
  at android.app.LoadedApk$ServiceDispatcher.doConnected(LoadedApk.java:1962)
```

`checkBillingSupported()` is only ever reached from an asynchronous callback —
`ServiceIAB`'s `onServiceConnected` (`IabHelper:240`) or the `BroadcastIAB`
connect listener (`IabHelper:259`). Both can fire after the host component is
gone and `dispose()` has set `mContext = null`, so the very first statement
throws.

Issue #21 pasted the *other* dereference on the same two lines — a null
`iabConnection` — which the `connection == null` guard added in 1.19 fixed. The
null `mContext` on the line above it is still open, and that's what this patch
covers.

### How it's reached

`onServiceDisconnected` clears `iabConnection`:

```java
public void disconnect() {
    iabConnection = null;
}
```

so a later `dispose()` skips `iabConnection.dispose(mContext)` and never
unbinds:

```java
public void dispose() {
    if (iabConnection != null) {
        iabConnection.dispose(mContext);   // skipped
    }
    mDisposed = true;
    mContext = null;                       // still happens
}
```

The `ServiceConnection` stays registered with `BIND_AUTO_CREATE`, so the
framework re-binds it when the market process comes back, and
`onServiceConnected` runs against a helper whose `mContext` is already null.
`ServiceIAB`'s own `disposed()` check doesn't catch it, because
`ServiceIAB.dispose()` was never called. That the stack reaches
`LoadedApk$ServiceDispatcher.doConnected` at all confirms `unbindService` was
never called for that connection.

This is why the reports are all from backgrounded apps — the sequence needs
`dispose()` to have already run.

### The patch

```java
if (mDisposed || mContext == null) {
    logger.logDebug("checkBillingSupported: helper already disposed, ignoring.");
    return;
}
```

The original Google IAB v3 helper this library is derived from had exactly this
guard — `if (mDisposed) return;` as the first line of `onServiceConnected`,
immediately before the same `getPackageName()` call. It was lost when that body
moved into `checkBillingSupported()`. Returning without notifying the listener
matches that original behaviour, and is what a disposed helper should do: the
listener belongs to a component that no longer exists.

### Possible follow-up (not in this PR)

The guard stops the crash but not its cause — after a disconnect, `dispose()`
can no longer unbind, so the connection leaks for the life of the process.
Keeping the `ServiceIAB` reference so `dispose()` can always unbind would fix
that, but it changes `disconnect()` semantics that `checkBillingSupported`'s
broadcast fallback depends on, so it seemed wrong to bundle in.

### Testing

Reasoned from crash reports, not a device repro — reproducing it needs the
market process to die and restart while the host app is backgrounded. Happy to
adjust the approach if you'd prefer the guard somewhere else.